### PR TITLE
Added PandocFormulaOptions customization helper

### DIFF
--- a/latex-formulae-image/src/Image/LaTeX/Render.hs
+++ b/latex-formulae-image/src/Image/LaTeX/Render.hs
@@ -14,6 +14,7 @@ module Image.LaTeX.Render
        , FormulaOptions (..)
        , displaymath
        , math
+       , mathColour
        )
        where
 
@@ -31,7 +32,7 @@ import System.Exit
 import Control.Exception
 import Control.Arrow(second)
 import Control.Applicative
-import Data.Monoid
+import Data.Semigroup
 import Prelude
 
 -- | This type contains all possible errors than can happen while rendering an equation.
@@ -78,6 +79,26 @@ displaymath = FormulaOptions "\\usepackage{amsmath}" "displaymath" 200
 -- | Use the @amsmath@ package, the @math@ environment, and 200dpi.
 math :: FormulaOptions
 math = FormulaOptions "\\usepackage{amsmath}\\usepackage{amsfonts}\\usepackage{stmaryrd}" "math" 200
+
+instance Semigroup FormulaOptions where
+    a <> b = FormulaOptions
+               (preamble a <> preamble b)
+               (environment a)
+               (max (dpi a) (dpi b))
+
+-- | Append this to 'FormulaOptions' to change math rendering colour to 'colour'.
+-- e.g. mathColour "ff0000"
+mathColour :: String -> FormulaOptions
+mathColour colour = FormulaOptions
+    ("\\usepackage{xcolor}\
+    \\\definecolor{fg}{HTML}{"
+    ++ colour ++
+    "}\\everymath\\expandafter{\
+    \\\the\\everymath \\color{fg}}\
+    \\\everydisplay\\expandafter{\
+    \\\the\\everydisplay \\color{fg}}")
+    ""
+    0
 
 -- | Sensible defaults for system environments. Works if @dvips@, @convert@, and @latex@ are recent enough and in your @$PATH@.
 defaultEnv :: EnvironmentOptions

--- a/latex-formulae-pandoc/src/Image/LaTeX/Render/Pandoc.hs
+++ b/latex-formulae-pandoc/src/Image/LaTeX/Render/Pandoc.hs
@@ -13,6 +13,7 @@ module Image.LaTeX.Render.Pandoc
        , PandocFormulaOptions(..)
        , ShrinkSize
        , defaultPandocFormulaOptions
+       , customize
          -- ** Error display functions
        , hideError
        , displayError
@@ -31,6 +32,7 @@ import Image.LaTeX.Render
 import Codec.Picture
 import Control.Applicative
 import Data.IORef
+import Data.Semigroup
 import System.FilePath
 
 import qualified Data.ByteString.Base64.Lazy as B64
@@ -69,6 +71,11 @@ defaultPandocFormulaOptions = PandocFormulaOptions
    , errorDisplay = displayError
    , formulaOptions = \case DisplayMath -> displaymath; _ -> math
    }
+
+-- | Appends custom 'FormluaOptions' to preamble.
+customize :: PandocFormulaOptions -> FormulaOptions -> PandocFormulaOptions
+customize pfo@(PandocFormulaOptions _ _ fo) opts =
+    pfo { formulaOptions = \mathtype -> (fo mathtype) <> opts }
 
 -- | Denominator for various dimensions. For high DPI displays, it can be useful to use values of 2 or 4, so that the dimensions
 --   of the image are a fraction of the actual image size, and the image appears more crisp. Otherwise, a value of 1 will always


### PR DESCRIPTION
I had a problem with changing the colour of rendered equations on my blog. Default ones are black and it doesn't work well with dark backgrounds. I managed to work it around by appending [custom preamble](https://tex.stackexchange.com/questions/211780/how-put-color-in-all-math-mode) to default one. Since it's relatively laborious thing to do, I've abstracted it out.

For example, suppose I want to change font colour to `#c5d4db`. Now, `mathColour "c5d4db"` returns `FormulaOptions` with following preamble

``` TeX
\usepackage{xcolor}
\definecolor{fg}{HTML}{c5d4db}
\everymath\expandafter{\the\everymath \color{fg}}
\everydisplay\expandafter{\the\everydisplay \color{fg}}
```
Since `FormulaOptions` has now `Semigroup` instance, we can append it to default preambles, like `math` or `displaymath`. With `customize` we can now easily add new features, e.g.

``` Haskell
defaultPandocFormulaOptions `customize` mathColour "c5d4db"
```
Hope I'm not missing anything and somebody will find it useful.